### PR TITLE
Allow custom HTTP connection pool size

### DIFF
--- a/iron_core.py
+++ b/iron_core.py
@@ -93,7 +93,7 @@ class IronClient:
         self.port = config["port"]
         self.api_version = config["api_version"]
         
-        pool_connections = config.get('pool_connections', requets.adapters.DEFAULT_POOLSIZE)
+        pool_connections = config.get('pool_connections', requests.adapters.DEFAULT_POOLSIZE)
         pool_maxsize = config.get('pool_maxsize', requests.adapters.DEFAULT_POOLSIZE)
         adapter = requests.adapters.HTTPAdapter(pool_connections=pool_connections, pool_maxsize=pool_maxsize)
         self.conn = requests.Session()


### PR DESCRIPTION
The underlying http client library `requests` allows custom HTTP connection pool sizes.

These changes allow `IronClient` users the same benefits. The defaults are the same ones `requests` uses.

The motivation is to solve high concurrency issues in the `iron_celery` library: https://github.com/iron-io/iron_celery/issues/4
