### PR TITLE
Modified the HTTP retry/backoff to also consider HTTP 502 & HTTP 504

### DIFF
--- a/iron_core.py
+++ b/iron_core.py
@@ -231,11 +231,12 @@ class IronClient(object):
 
         r = self._doRequest(url, method, body, headers)
 
-        if r.status_code == requests.codes['service_unavailable'] and retry:
+        retry_http_codes = [503, 504]
+        if r.status_code in retry_http_codes and retry:
             tries = 5
             delay = .5
             backoff = 2
-            while r.status_code == requests.codes['service_unavailable'] and tries > 0:
+            while r.status_code in retry_http_codes and tries > 0:
                 tries -= 1
                 time.sleep(delay)
                 delay *= backoff


### PR DESCRIPTION
We're receiving a far amount of HTTP 504 "Gateway Timeout" in our production environment right now, so it seems reasonable to handle with the built-in retry logic.

**Implementation note**: Switched from the undocumented `requests.codes['service_unavailable']` to a plain `503`, since HTTP status codes do not change and is better documented elsewhere (e.g. on Wikipedia -- http://en.wikipedia.org/wiki/List_of_HTTP_status_codes)