### PR TITLE
Fix for use on google app engine

### DIFF
--- a/iron_core.py
+++ b/iron_core.py
@@ -118,9 +118,12 @@ class IronClient(object):
         if product in products:
             config["host"] = products[product]["host"]
             config["api_version"] = products[product]["version"]
-
-        config = configFromFile(config,
-                os.path.expanduser("~/.iron.json"), product)
+        
+        try:
+            config = configFromFile(config,
+                    os.path.expanduser("~/.iron.json"), product)
+        except:
+            pass
         config = configFromEnv(config)
         config = configFromEnv(config, product)
         config = configFromFile(config, "iron.json", product)


### PR DESCRIPTION
The use of`os.path.expanduser` is not allowed in google app engine. Using a try statement here enables its use.