### PR TITLE
Migrate Iron Worker API endpoint to new endpoint

### DIFF
--- a/iron_core.py
+++ b/iron_core.py
@@ -103,7 +103,7 @@ class IronClient(object):
         }
         products = {
                 "iron_worker": {
-                    "host": "worker-aws-us-east-1.iron.io",
+                    "host": "iron-iw.us-east-1.antimony.io",
                     "version": 2
                 },
                 "iron_mq": {


### PR DESCRIPTION
To move to the new Iron.io endpoint, our system depends on this package having the latest endpoint.